### PR TITLE
Build hidapi against latest mingw-w64 headers

### DIFF
--- a/hidapi_parser/hidapi_parser.c
+++ b/hidapi_parser/hidapi_parser.c
@@ -29,6 +29,9 @@
 
 #ifdef _WIN32
 #include <windows.h>
+// for MinGW < 5.3 include locally provided "../windows hidsdi.h" rather
+// than #include <hidsdi.h>:
+// #include "../windows/hidsdi.h"
 #include <hidsdi.h>
 #endif
 

--- a/hidapi_parser/hidapi_parser.c
+++ b/hidapi_parser/hidapi_parser.c
@@ -29,11 +29,7 @@
 
 #ifdef _WIN32
 #include <windows.h>
-#ifdef __MINGW32__
-#include "../windows/hidsdi.h"
-#else
 #include <hidsdi.h>
-#endif
 #endif
 
 #include "hidapi_parser.h"

--- a/windows/hid.c
+++ b/windows/hid.c
@@ -21,12 +21,7 @@
 ********************************************************/
 
 #include <windows.h>
-
-#ifdef __MINGW32__
-#include "./hidsdi.h"
-#else
 #include <hidsdi.h>
-#endif
 
 #ifndef _NTDEF_
 typedef LONG NTSTATUS;
@@ -35,6 +30,7 @@ typedef LONG NTSTATUS;
 #ifdef __MINGW32__
 #include <ntdef.h>
 #include <winbase.h>
+#include <devpropdef.h>
 #endif
 
 #ifdef __CYGWIN__

--- a/windows/hid.c
+++ b/windows/hid.c
@@ -21,6 +21,9 @@
 ********************************************************/
 
 #include <windows.h>
+// for MinGW < 5.3 include locally provided "../windows hidsdi.h" rather
+// than #include <hidsdi.h>:
+// #include "./hidsdi.h"
 #include <hidsdi.h>
 
 #ifndef _NTDEF_


### PR DESCRIPTION
Not guarded, perhaps breaks old headers build.

This is a complement to [another PR, which together allow to build supercollider with the latest stock MSys2/mingw-w64 tools](https://github.com/supercollider/supercollider/pull/2473).