### PR TITLE
Fix compiler warning

### DIFF
--- a/hidapi_parser/hidapi_parser.c
+++ b/hidapi_parser/hidapi_parser.c
@@ -1956,6 +1956,7 @@ void hid_parse_element_info( struct hid_dev_desc * devdesc )
 		}
 		default:
 		{
+		  // TODO: Handle unknown types
 		  printf("WARNING: unknown tIOHIDElementType: %d. Defaulting to io_type 1", tIOHIDElementType);
 		  new_element->io_type = 1;
 		  break;

--- a/hidapi_parser/hidapi_parser.c
+++ b/hidapi_parser/hidapi_parser.c
@@ -1954,6 +1954,12 @@ void hid_parse_element_info( struct hid_dev_desc * devdesc )
 // 		  printf("type: Feature, ");
 		  break;
 		}
+		default:
+		{
+		  printf("WARNING: unknown tIOHIDElementType: %d. Defaulting to io_type 1", tIOHIDElementType);
+		  new_element->io_type = 1;
+		  break;
+		}
 	      }
 	      new_element->parent_collection = parent_collection;
 	      new_element->usage_page = usagePage;


### PR DESCRIPTION
This covers a compiler warning in the case where the HIDElementType is Collection.

The solution used was to add a default statement to the switch.

@sensestage do you have any thoughts on this? It seems to me like there's no consistent exception handling system here, so I just printed a warning. Since this is lower-level and designed for robust performance, I thought attempting a solution rather than failing via exception or assert would be more graceful and appropriate to this library.