### PR TITLE
cmake: bump to 3.0, use modern project() syntax

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,15 +1,6 @@
-cmake_minimum_required(VERSION 2.8)
-if(${CMAKE_MAJOR_VERSION} GREATER 2)
-  cmake_policy(SET CMP0048 OLD)
-endif(${CMAKE_MAJOR_VERSION} GREATER 2)
+cmake_minimum_required(VERSION 3.0)
 
-project(hidapi)
-
-set(VERSION_MAJOR "0")
-set(VERSION_MINOR "7")
-set(VERSION_PATCH "1")
-set(VERSION "${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}")
-
+project(hidapi VERSION 0.7.1)
 
 option(HID_DEBUG_PARSER "verbose parser debugging output" OFF)
 


### PR DESCRIPTION
On CMake 3.11, this project currently produces the following warning:

```
CMake Deprecation Warning at external_libraries/hidapi/CMakeLists.txt:3 (cmake_policy):
  The OLD behavior for policy CMP0048 will be removed from a future version
  of CMake.

  The cmake-policies(7) manual explains that the OLD behaviors of all
  policies are deprecated and that a policy should be set to OLD only under
  specific short-term circumstances.  Projects should be ported to the NEW
  behavior and not rely on setting a policy to OLD.
```

since we're bumping the main project cmake minimum to 3.5, bumping the minimum here to 3.0 should be fine.