### PR TITLE
CMake: fix link & include properties on targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,11 +49,9 @@ if(CMAKE_SYSTEM_NAME MATCHES "Linux" OR CMAKE_SYSTEM_NAME MATCHES "FreeBSD")
 
   if (HIDAPI STREQUAL hidraw)
     add_subdirectory(linux)
-  #   set( hidapi_source ${hidapi_SOURCE_DIR}/linux )
     link_directories( ${UDEV_LIBRARIES} )
   elseif (HIDAPI STREQUAL libusb)
     add_subdirectory(libusb)
-  #   set( hidapi_source ${hidapi_SOURCE_DIR}/libusb )
     link_directories( ${LIBUSB_1_LIBRARIES} ${PTHREADS_LIBRARIES} )
   endif()
 

--- a/libusb/CMakeLists.txt
+++ b/libusb/CMakeLists.txt
@@ -22,10 +22,6 @@ IF(${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD")
   find_package( IConv )
 ENDIF(${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD")
 
-#TODO: ADD ICONV
-# set( hidapi_INCLUDE_DIRS ${LIBUSB_1_INCLUDE_DIRS} ${hidapi_SOURCE_DIR}/hidapi/ ${PTHREADS_INCLUDE_DIR})
-# set( hidapi_LIBS ${LIBUSB_1_LIBRARIES} ${PTHREADS_LIBRARIES})
-# set( hidapi_SRCS hid.c )
 
 include_directories( ${LIBUSB_1_INCLUDE_DIRS} ${PTHREADS_INCLUDE_DIR} ${hidapi_SOURCE_DIR}/hidapi/ )
 add_library( hidapi STATIC hid.c )

--- a/libusb/CMakeLists.txt
+++ b/libusb/CMakeLists.txt
@@ -14,15 +14,13 @@ message(STATUS "    libusb" )
 # target_link_libraries( hid-usb -lrt)
 
 #libusb 1.0
-
-find_package( libusb-1.0 )
+find_package(libusb-1.0 REQUIRED)
 
 ## NOT TESTED:
 IF(${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD")
   find_package( IConv )
 ENDIF(${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD")
 
-
-include_directories( ${LIBUSB_1_INCLUDE_DIRS} ${PTHREADS_INCLUDE_DIR} ${hidapi_SOURCE_DIR}/hidapi/ )
-add_library( hidapi STATIC hid.c )
-target_link_libraries( hidapi ${LIBUSB_1_LIBRARIES} ${PTHREADS_LIBRARIES} )
+add_library(hidapi STATIC hid.c)
+target_link_libraries(hidapi ${LIBUSB_1_LIBRARIES} ${PTHREADS_LIBRARIES})
+target_include_directories(hidapi ${LIBUSB_1_INCLUDE_DIRS} ${PTHREADS_INCLUDE_DIR} ${hidapi_SOURCE_DIR}/hidapi)

--- a/linux/CMakeLists.txt
+++ b/linux/CMakeLists.txt
@@ -3,17 +3,6 @@ message(STATUS "    linux hidraw" )
 #udev
 find_package(UDev)
 
-# include_directories(${UDEV_INCLUDE_DIR} ${CMAKE_SOURCE_DIR}/hidapi/)
-# link_libraries(${UDEV_LIBRARIES})
-
-# message( "hidapi source dir is: ${hidapi_SOURCE_DIR}" )
-
-# set( hidapi_INCLUDE_DIRS ${UDEV_INCLUDE_DIR} ${hidapi_SOURCE_DIR}/hidapi/)
-# set( hidapi_LIBS ${UDEV_LIBRARIES})
-# set( hidapi_SRCS hid.c )
-
-# message( "hidapi include dirs are: ${hidapi_INCLUDE_DIRS}" )
-
 include_directories( ${UDEV_INCLUDE_DIR} ${hidapi_SOURCE_DIR}/hidapi/ )
 add_library( hidapi STATIC hid.c )
 target_link_libraries( hidapi ${UDEV_LIBRARIES} )

--- a/linux/CMakeLists.txt
+++ b/linux/CMakeLists.txt
@@ -1,9 +1,6 @@
 message(STATUS "    linux hidraw" )
 
-#udev
-find_package(UDev)
-
-include_directories( ${UDEV_INCLUDE_DIR} ${hidapi_SOURCE_DIR}/hidapi/ )
-add_library( hidapi STATIC hid.c )
-target_link_libraries( hidapi ${UDEV_LIBRARIES} )
-# link_directories( hidapi ${UDEV_LIBRARIES} )
+find_package(UDev REQUIRED)
+add_library(hidapi STATIC hid.c)
+target_link_libraries(hidapi PUBLIC ${UDEV_LIBRARIES})
+target_include_directories(hidapi PUBLIC ${UDEV_INCLUDE_DIR} ${hidapi_SOURCE_DIR}/hidapi)


### PR DESCRIPTION
Probably fixes the error encountered in github.com/supercollider/supercollider/pulls/4896

Since include directories added with include_directories() are not part of the public interface
(at least as far as i can tell) they are not passed along to other targets linking with hidapi (like sclang).