### PR TITLE
Fix memory leak in hid_parse_report_descriptor

### DIFF
--- a/hidapi_parser/hidapi_parser.c
+++ b/hidapi_parser/hidapi_parser.c
@@ -696,6 +696,8 @@ int hid_parse_report_descriptor( unsigned char* descr_buf, int size, struct hid_
   printf("----------- end setting report ids --------------\n " );
 #endif
 
+  hid_free_collection(device_collection);
+
   return 0;
 }
 


### PR DESCRIPTION
This is allocated at the top of the function but never free'd.