### PR TITLE
Revert #16

### DIFF
--- a/hidapi_parser/hidapi_parser.c
+++ b/hidapi_parser/hidapi_parser.c
@@ -696,8 +696,6 @@ int hid_parse_report_descriptor( unsigned char* descr_buf, int size, struct hid_
   printf("----------- end setting report ids --------------\n " );
 #endif
 
-  hid_free_collection(device_collection);
-
   return 0;
 }
 


### PR DESCRIPTION
It seems that #16 introduced a bug on Linux: https://github.com/supercollider/supercollider/issues/6016

I don't know why that would be. However, reverting #16 seems to fix the reported issue. In that case I proposed to revert that change, since I'm not aware of any other issues reported with HID in quite some time regarding the supposed memory leak.

I haven't tested this beyond confirming with the person who reported the issue in SC.