### PR TITLE
fix MinGW errror incompatible-pointer-types

### DIFF
--- a/hidapi_parser/hidapi_parser.c
+++ b/hidapi_parser/hidapi_parser.c
@@ -1586,7 +1586,7 @@ void hid_parse_element_info( struct hid_dev_desc * devdesc ){
     // To keep track of indices
     int new_index = 0;
 
-    int numColls = 0;
+    ULONG numColls = 0;
 
     NTSTATUS nt_res;
     PHIDP_PREPARSED_DATA pp_data = NULL;


### PR DESCRIPTION
This error was initially reported in the SuperCollider repository. See https://github.com/supercollider/supercollider/issues/6435.

The second argument of function`HidP_GetLinkCollectionNodes` is a pointer to an unsigned long, so I make adjustment accordingly.

I don't really test it (It cross-compiled just fine on my Linux machine using mingw64), but I've noticed that on Windows, both `int` and `long` types have the [same size](https://learn.microsoft.com/en-us/cpp/cpp/fundamental-types-cpp?view=msvc-170#sizes-of-built-in-types). So, I believe the change is probably safe.