### PR TITLE
Bump cmake minimum version to 3.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(hidapi VERSION 0.7.1)
 


### PR DESCRIPTION
Necessary due to https://github.com/supercollider/supercollider/issues/6696

edit: see a modified test-run @ https://github.com/capital-G/supercollider/actions/runs/14222774994?pr=4

edit2: should we maybe bump to 3.10 b/c 3.5 is also already deprecated?
Bumping to 3.5 seems to remove Ubuntu 16.04 support, but that just seems how it is now :/