### PR TITLE
Bump min cmake version to 3.12

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.12)
 
 project(hidapi VERSION 0.7.1)
 


### PR DESCRIPTION
Removes a deprecation warning during configuration of SC which probably creates some longevity of the release on newer platforms?
As we are already requiring 3.12 in SC, we can also bump it here.

For some reason other external librarys in SuperCollider are using an even older min version but don't yield a warning (e.g. osc_pack is using 2.6, but maybe we do not import their CMake file?)

Merge note: Branch name is wrong and should be fixed to 3.12